### PR TITLE
Added a link to download historical stubs

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -70,7 +70,10 @@
 
     </div>
     <div>
-    	<p><small><em>Paystubs from prior to 2012 can be downloaded via <a href="https://staffweb.cru.org/pay-benefits-staff-expenses/payroll/history/index.htm" target="_blank">Staff Web</a>.</em></small></p>
+    	<p><small><em>
+    	  Downloads of your paystubs through June 2014 are available on 
+    	  <a href="https://staffweb.cru.org/pay-benefits-staff-expenses/payroll/history/index.htm" target="_blank">Staff Web</a>.
+    	</em></small></p>
     </div>
   </div>  
 


### PR DESCRIPTION
I believe the historical stubs will be available for both spouses,
therefore it shows up on both tabs. If that is incorrect (and they can
only download their own), this link will need to be moved into the
primary tab.
