### PR TITLE
Disabled staff should have access to this data.

### DIFF
--- a/js/ng-app-paycheck-history/controllers/dashboard.js
+++ b/js/ng-app-paycheck-history/controllers/dashboard.js
@@ -15,7 +15,7 @@
       });
 
       scope.myEmployee.then(function(employee){
-        if (!_.contains(['USS', 'INT', 'RCE'], employee.payGroup))
+        if (!_.contains(['USS', 'INT', 'RCE', 'DIS'], employee.payGroup))
           window.alert("This page only works for full-time supported staff.")
       });
 


### PR DESCRIPTION
This PR addresses the Helpscout issue [here](https://secure.helpscout.net/conversation/121186433/14532/). The alert is not preventing the data from coming through, but it shouldn't be showing for this paygroup.