### PR TITLE
HS 42103 - fix Function.caller Error in Safari

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,6 +1,12 @@
-// usage: log('inside coolFunc', this, arguments);
-// paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
-window.log = function f(){ log.history = log.history || []; log.history.push(arguments); if(this.console) { var args = arguments, newarr; args.callee = args.callee.caller; newarr = [].slice.call(args); if (typeof console.log === 'object') log.apply.call(console.log, console, newarr); else console.log.apply(console, newarr);}};
+// usage: log('inside coolFunc',this,arguments);
+// http://paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
+window.log = function(){
+  log.history = log.history || [];   // store logs to an array for reference
+  log.history.push(arguments);
+  if(this.console){
+    console.log( Array.prototype.slice.call(arguments) );
+  }
+};
 
 // make it safe to use console.log always
 (function(a){function b(){}for(var c="assert,count,debug,dir,dirxml,error,exception,group,groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,time,timeEnd,trace,warn".split(","),d;!!(d=c.pop());){a[d]=a[d]||b;}})


### PR DESCRIPTION
Fixes [HS 42103](https://secure.helpscout.net/conversation/180649319/42103/?folderId=381624).

This updates Paul Irish's log wrapper to his [most recently published version](http://www.paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/),
which is simpler than what was here before and doesn't use 'caller' or 'callee'.
These are deprecated and Safari now fails when these are called on a strict mode function,
such as those in easy-xdm.js.

I'm also using the non-minified version, because it's easier to understand.
